### PR TITLE
Use database/sql to replace gorm

### DIFF
--- a/internal/db/new.go
+++ b/internal/db/new.go
@@ -1,0 +1,22 @@
+package db
+
+import (
+	"database/sql"
+)
+
+var dbh *sql.DB
+
+func New() (*sql.DB, error) {
+	if dbh != nil {
+		return dbh, nil
+	}
+
+	var err error
+
+	dbh, err = sql.Open("pgx", `postgresql://postgres:postgres@localhost:5432/goteams`)
+	if err != nil {
+		return nil, err
+	}
+
+	return dbh, nil
+}

--- a/internal/players/services/create.go
+++ b/internal/players/services/create.go
@@ -3,23 +3,12 @@ package services
 import (
 	"strings"
 
-	"goteams/internal/repository"
+	repo "goteams/internal/repository/players"
 )
 
 func Create(dto *CreatePlayer) (*Player, error) {
-	repo, err := repository.New()
-	if err != nil {
-		return nil, err
-	}
-
 	player := createToPlayer(dto)
-	// TODO: Add validation
-
-	if err := repo.DB.Create(player).Error; err != nil {
-		return nil, err
-	}
-
-	return player, nil
+	return repo.Create(player)
 }
 
 func createToPlayer(dto *CreatePlayer) *Player {

--- a/internal/players/services/fetch.go
+++ b/internal/players/services/fetch.go
@@ -1,35 +1,13 @@
 package services
 
 import (
-	"goteams/internal/repository"
+	repo "goteams/internal/repository/players"
 )
 
 func Fetch() ([]Player, error) {
-	repo, err := repository.New()
-	if err != nil {
-		return nil, err
-	}
-
-	var players []Player
-
-	if err := repo.Find(&players).Error; err != nil {
-		return nil, err
-	}
-
-	return players, nil
+	return repo.Find()
 }
 
 func FetchById(id string) (*Player, error) {
-	repo, err := repository.New()
-	if err != nil {
-		return nil, err
-	}
-
-	var player Player
-
-	if err := repo.First(&player, "id = ?", id).Error; err != nil {
-		return nil, err
-	}
-
-	return &player, nil
+	return repo.FindByID(id)
 }

--- a/internal/repository/players/create.go
+++ b/internal/repository/players/create.go
@@ -1,0 +1,11 @@
+package players
+
+func Create(player *Player) (*Player, error) {
+	stmt, err := createStmt()
+	if err != nil {
+		return nil, err
+	}
+
+	row := stmt.QueryRow(player.Name, player.Number)
+	return scan(row)
+}

--- a/internal/repository/players/find.go
+++ b/internal/repository/players/find.go
@@ -1,0 +1,32 @@
+package players
+
+func Find() ([]Player, error) {
+	stmt, err := findStmt()
+	if err != nil {
+		return nil, err
+	}
+
+	var players []Player
+
+	rows, err := stmt.Query()
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+	for rows.Next() {
+		player, err := scan(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		players = append(players, *player)
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	return players, nil
+}

--- a/internal/repository/players/find_by_id.go
+++ b/internal/repository/players/find_by_id.go
@@ -1,0 +1,11 @@
+package players
+
+func FindByID(id string) (*Player, error) {
+	stmt, err := findByIDStmt()
+	if err != nil {
+		return nil, err
+	}
+
+	row := stmt.QueryRow(id)
+	return scan(row)
+}

--- a/internal/repository/players/scan.go
+++ b/internal/repository/players/scan.go
@@ -1,0 +1,19 @@
+package players
+
+type scanable interface {
+	Scan(dest ...interface{}) error
+}
+
+func scan(s scanable) (*Player, error) {
+	var player Player
+
+	err := s.Scan(
+		&player.ID, &player.Name, &player.Number,
+		&player.CreatedAt, &player.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &player, nil
+}

--- a/internal/repository/players/sqls.go
+++ b/internal/repository/players/sqls.go
@@ -1,0 +1,20 @@
+package players
+
+const sqlSelectPlayers = `
+SELECT id, name, number, created_at, updated_at
+FROM   players
+WHERE  deleted_at IS NULL
+`
+
+const sqlSelectPlayerById = `
+SELECT id, name, number, created_at, updated_at
+FROM   players
+WHERE  deleted_at IS NULL
+AND    id = $1
+`
+
+const sqlInsertPlayer = `
+INSERT INTO players(name, number, created_at, updated_at)
+VALUES($1, $2, NOW(), NOW())
+RETURNING id, name, number, created_at, updated_at
+`

--- a/internal/repository/players/stmts.go
+++ b/internal/repository/players/stmts.go
@@ -1,0 +1,53 @@
+package players
+
+import (
+	"database/sql"
+
+	"goteams/internal/db"
+)
+
+var stmtFind *sql.Stmt
+var stmtFindByID *sql.Stmt
+var stmtCreate *sql.Stmt
+
+func createStmt() (*sql.Stmt, error) {
+	if stmtCreate != nil {
+		return stmtCreate, nil
+	}
+
+	dbh, err := db.New()
+	if err != nil {
+		return nil, err
+	}
+
+	stmtCreate, err := dbh.Prepare(sqlInsertPlayer)
+	return stmtCreate, err
+}
+
+func findStmt() (*sql.Stmt, error) {
+	if stmtFind != nil {
+		return stmtFind, nil
+	}
+
+	dbh, err := db.New()
+	if err != nil {
+		return nil, err
+	}
+
+	stmtFind, err := dbh.Prepare(sqlSelectPlayers)
+	return stmtFind, err
+}
+
+func findByIDStmt() (*sql.Stmt, error) {
+	if stmtFindByID != nil {
+		return stmtFindByID, nil
+	}
+
+	dbh, err := db.New()
+	if err != nil {
+		return nil, err
+	}
+
+	stmtFindByID, err := dbh.Prepare(sqlSelectPlayerById)
+	return stmtFindByID, err
+}

--- a/internal/repository/players/types.go
+++ b/internal/repository/players/types.go
@@ -1,0 +1,8 @@
+package players
+
+import (
+	"goteams/internal/models"
+)
+
+type Player = models.Player
+type Base = models.Base

--- a/internal/repository/teams/create.go
+++ b/internal/repository/teams/create.go
@@ -1,0 +1,11 @@
+package teams
+
+func Create(team *Team) (*Team, error) {
+	stmt, err := createStmt()
+	if err != nil {
+		return nil, err
+	}
+
+	row := stmt.QueryRow(team.Name)
+	return scan(row)
+}

--- a/internal/repository/teams/find.go
+++ b/internal/repository/teams/find.go
@@ -1,0 +1,32 @@
+package teams
+
+func Find() ([]Team, error) {
+	stmt, err := findStmt()
+	if err != nil {
+		return nil, err
+	}
+
+	var teams []Team
+
+	rows, err := stmt.Query()
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+	for rows.Next() {
+		team, err := scan(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		teams = append(teams, *team)
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	return teams, nil
+}

--- a/internal/repository/teams/find_by_id.go
+++ b/internal/repository/teams/find_by_id.go
@@ -1,0 +1,11 @@
+package teams
+
+func FindByID(id string) (*Team, error) {
+	stmt, err := findByIDStmt()
+	if err != nil {
+		return nil, err
+	}
+
+	row := stmt.QueryRow(id)
+	return scan(row)
+}

--- a/internal/repository/teams/scan.go
+++ b/internal/repository/teams/scan.go
@@ -1,0 +1,31 @@
+package teams
+
+import (
+	"encoding/json"
+)
+
+type scanable interface {
+	Scan(dest ...interface{}) error
+}
+
+func scan(s scanable) (*Team, error) {
+	var team Team
+	var playersData []byte
+
+	err := s.Scan(&team.ID, &team.Name, &team.CreatedAt, &team.UpdatedAt, &playersData)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(playersData) > 0 {
+		var players []*Player
+		err = json.Unmarshal(playersData, &players)
+		if err != nil {
+			return nil, err
+		}
+
+		team.Players = players
+	}
+
+	return &team, nil
+}

--- a/internal/repository/teams/sqls.go
+++ b/internal/repository/teams/sqls.go
@@ -46,3 +46,18 @@ INSERT INTO teams(name, created_at, updated_at)
 VALUES($1, NOW(), NOW())
 RETURNING id, name, created_at, updated_at, NULL
 `
+
+const sqlInsertTeamPlayer = `
+INSERT INTO team_players(team_id, player_id)
+VALUES($1, $2) ON CONFLICT DO NOTHING
+`
+
+const sqlDeleteTeamPlayers = `
+DELETE FROM team_players WHERE team_id = $1
+`
+
+const sqlUpdateTeamPlayer = `
+UPDATE teams
+SET name = $2, updated_at = NOW()
+WHERE id = $1
+`

--- a/internal/repository/teams/sqls.go
+++ b/internal/repository/teams/sqls.go
@@ -1,0 +1,48 @@
+package teams
+
+const sqlSelectTeams = `
+SELECT t.id, t.name, t.created_at, t.updated_at,
+       COALESCE(
+         JSON_AGG(JSON_BUILD_OBJECT(
+           'id',        p.id,
+           'name',      p.name,
+           'createdAt', p.created_at,
+           'updatedAt', p.updated_at
+         )) FILTER (WHERE p.id IS NOT NULL),
+         NULL
+       )
+FROM   teams t
+LEFT
+JOIN   team_players tp ON (t.id = tp.team_id)
+LEFT
+JOIN   players p ON (p.id = tp.player_id)
+WHERE  t.deleted_at IS NULL
+GROUP BY t.id
+`
+
+const sqlSelectTeamById = `
+SELECT t.id, t.name, t.created_at, t.updated_at,
+       COALESCE(
+         JSON_AGG(JSON_BUILD_OBJECT(
+           'id',        p.id,
+           'name',      p.name,
+           'createdAt', p.created_at,
+           'updatedAt', p.updated_at
+         )) FILTER (WHERE p.id IS NOT NULL),
+         NULL
+       )
+FROM   teams t
+LEFT
+JOIN   team_players tp ON (t.id = tp.team_id)
+LEFT
+JOIN   players p ON (p.id = tp.player_id)
+WHERE  t.deleted_at IS NULL
+AND    t.id = $1
+GROUP BY t.id
+`
+
+const sqlInsertTeam = `
+INSERT INTO teams(name, created_at, updated_at)
+VALUES($1, NOW(), NOW())
+RETURNING id, name, created_at, updated_at, NULL
+`

--- a/internal/repository/teams/stmts.go
+++ b/internal/repository/teams/stmts.go
@@ -1,0 +1,53 @@
+package teams
+
+import (
+	"database/sql"
+
+	"goteams/internal/db"
+)
+
+var stmtFind *sql.Stmt
+var stmtFindByID *sql.Stmt
+var stmtCreate *sql.Stmt
+
+func createStmt() (*sql.Stmt, error) {
+	if stmtCreate != nil {
+		return stmtCreate, nil
+	}
+
+	dbh, err := db.New()
+	if err != nil {
+		return nil, err
+	}
+
+	stmtCreate, err := dbh.Prepare(sqlInsertTeam)
+	return stmtCreate, err
+}
+
+func findStmt() (*sql.Stmt, error) {
+	if stmtFind != nil {
+		return stmtFind, nil
+	}
+
+	dbh, err := db.New()
+	if err != nil {
+		return nil, err
+	}
+
+	stmtFind, err := dbh.Prepare(sqlSelectTeams)
+	return stmtFind, err
+}
+
+func findByIDStmt() (*sql.Stmt, error) {
+	if stmtFindByID != nil {
+		return stmtFindByID, nil
+	}
+
+	dbh, err := db.New()
+	if err != nil {
+		return nil, err
+	}
+
+	stmtFindByID, err := dbh.Prepare(sqlSelectTeamById)
+	return stmtFindByID, err
+}

--- a/internal/repository/teams/types.go
+++ b/internal/repository/teams/types.go
@@ -1,0 +1,8 @@
+package teams
+
+import (
+	"goteams/internal/models"
+)
+
+type Team = models.Team
+type Player = models.Player

--- a/internal/repository/teams/update.go
+++ b/internal/repository/teams/update.go
@@ -1,0 +1,60 @@
+package teams
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"goteams/internal/db"
+)
+
+func Update(id string, name string, playerIDs *[]uint) (*Team, error) {
+	dbh, err := db.New()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+
+	tx, err := dbh.BeginTx(ctx, nil)
+	defer tx.Rollback()
+
+	err = updateTx(ctx, tx, id, name, playerIDs)
+	if err != nil {
+
+		return nil, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return FindByID(id)
+}
+
+func updateTx(ctx context.Context, tx *sql.Tx, id string, name string, playerIDs *[]uint) (err error) {
+	if name := strings.TrimSpace(name); name != "" {
+		_, err = tx.ExecContext(ctx, sqlUpdateTeamPlayer, id, name)
+		if err != nil {
+			return
+		}
+	}
+
+	if playerIDs == nil {
+		return
+	}
+
+	_, err = tx.ExecContext(ctx, sqlDeleteTeamPlayers, id)
+	if err != nil {
+		return
+	}
+
+	for _, playerID := range *playerIDs {
+		_, err = tx.ExecContext(ctx, sqlInsertTeamPlayer, id, playerID)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}

--- a/internal/teams/dtos/update_dto.go
+++ b/internal/teams/dtos/update_dto.go
@@ -1,6 +1,6 @@
 package dtos
 
 type UpdateDTO struct {
-	Name      string `json:"name"`
-	PlayerIDs []uint `json:"playerIds"`
+	Name      string  `json:"name"`
+	PlayerIDs *[]uint `json:"playerIds"`
 }

--- a/internal/teams/services/create.go
+++ b/internal/teams/services/create.go
@@ -3,23 +3,14 @@ package services
 import (
 	"strings"
 
-	"goteams/internal/repository"
+	repo "goteams/internal/repository/teams"
 )
 
 func Create(dto *CreateTeam) (*Team, error) {
-	repo, err := repository.New()
-	if err != nil {
-		return nil, err
-	}
-
 	team := createToTeam(dto)
 	// TODO: Add validation
 
-	if err := repo.DB.Create(team).Error; err != nil {
-		return nil, err
-	}
-
-	return team, nil
+	return repo.Create(team)
 }
 
 func createToTeam(dto *CreateTeam) *Team {

--- a/internal/teams/services/fetch.go
+++ b/internal/teams/services/fetch.go
@@ -1,33 +1,13 @@
 package services
 
 import (
-	"goteams/internal/repository"
+	repo "goteams/internal/repository/teams"
 )
 
 func Fetch() (teams []Team, err error) {
-	repo, err := repository.New()
-	if err != nil {
-		return
-	}
-
-	result := repo.Preload("Players").Find(&teams)
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	return
+	return repo.Find()
 }
 
 func FetchById(id string) (team *Team, err error) {
-	repo, err := repository.New()
-	if err != nil {
-		return
-	}
-
-	result := repo.Preload("Players").First(&team, "id = ?", id)
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	return
+	return repo.FindByID(id)
 }

--- a/internal/teams/services/update.go
+++ b/internal/teams/services/update.go
@@ -1,59 +1,9 @@
 package services
 
 import (
-	"strings"
-
-	"gorm.io/gorm"
-
-	"goteams/internal/repository"
+	repo "goteams/internal/repository/teams"
 )
 
 func Update(teamID string, dto *UpdateTeam) (*Team, error) {
-	repo, err := repository.New()
-	if err != nil {
-		return nil, err
-	}
-
-	team := &Team{}
-
-	if err := repo.First(&team, "id = ?", teamID).Error; err != nil {
-		return nil, err
-	}
-
-	if err := repo.Transaction(updateTeamTx(team, dto)); err != nil {
-		return nil, err
-	}
-
-	return team, nil
-}
-
-func updateTeamTx(team *Team, dto *UpdateTeam) func(tx *gorm.DB) error {
-	return func(tx *gorm.DB) (err error) {
-		if err = updatePlayers(tx, team, dto); err != nil {
-			return
-		}
-
-		if name := strings.TrimSpace(dto.Name); name != "" {
-			team.Name = name
-			err = tx.Save(team).Error
-		}
-
-		return
-	}
-}
-
-func updatePlayers(tx *gorm.DB, team *Team, dto *UpdateTeam) error {
-	if dto.PlayerIDs == nil {
-		return nil
-	}
-
-	var players []*Player
-
-	if len(dto.PlayerIDs) > 0 {
-		if err := tx.Find(&players, dto.PlayerIDs).Error; err != nil {
-			return err
-		}
-	}
-
-	return tx.Model(team).Association("Players").Replace(players)
+	return repo.Update(teamID, dto.Name, dto.PlayerIDs)
 }


### PR DESCRIPTION
Change summary: 

- Replace gorm with database/sql and plain sql
- Fetch players 
- Create players
- Fetch teams
- Create teams

A few observations: 
- More custom code, but less magic from gorm
- some more code if tests are added
- Use postgres json features to fetch associations in one statement, whilst there will be multiple queries in gorm
- Direct use of `join`
- Use `insert ... return` to fetch created records
